### PR TITLE
Add responsive mobile layout to deck viewer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,12 @@ services:
 
   opcc-frontend:
     container_name: opcc-frontend
+    env_file:
+      - .env
     build:
       context: ./frontend
       args:
-        # Use localhost for browser requests (client-side)
-        NEXT_PUBLIC_API_URL: http://localhost:3001
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     restart: always
     ports:
       - '8086:3000'

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   images: {
     domains: [
       // Add any external image domains you use
-      'tcg.laeradsphere.com',
+      '1pc.laeradsphere.com',
       'en.onepiece-cardgame.com',
       'asia-en.onepiece-cardgame.com'
     ],
@@ -28,7 +28,7 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'tcg.laeradsphere.com',
+        hostname: '1pc.laeradsphere.com',
         port: '',
         pathname: '/**',
       }

--- a/frontend/src/components/CardSearch.js
+++ b/frontend/src/components/CardSearch.js
@@ -5,7 +5,7 @@ import {
   Box, Text, VStack, HStack, Spinner,
   useDisclosure, IconButton, FormControl, FormLabel, Switch,
   Tooltip, Slider, SliderTrack, SliderFilledTrack, SliderThumb,
-  Menu, MenuButton, MenuList, MenuItem
+  Menu, MenuButton, MenuList, MenuItem, useBreakpointValue
 } from '@chakra-ui/react';
 import { QuestionOutlineIcon } from '@chakra-ui/icons';
 import { FiMapPin, FiSearch, FiHash, FiType, FiTag } from 'react-icons/fi';
@@ -171,6 +171,9 @@ function CardSearch({
   const lastSearchParamsRef = useRef('');
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+  // Check if we should use mobile layout for controls
+  const isMobile = useBreakpointValue({ base: true, md: false });
 
   useEffect(() => {
     setIsClient(true);
@@ -476,100 +479,206 @@ function CardSearch({
 
         {/* Controls */}
         {shouldShowFilters && (
-          <HStack justify="space-between" align="center">
-            <HStack spacing={4}>
-              <Tooltip label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}>
-                <IconButton
-                  icon={viewMode === 'list' ? <FaGripHorizontal /> : <FaGripLines />}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setViewMode(viewMode === 'list' ? 'thumbnails' : 'list')}
-                  aria-label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}
-                />
-              </Tooltip>
+          <VStack spacing={3} align="stretch">
+            {isMobile ? (
+              // Mobile layout: Multiple rows
+              <>
+                {/* First row: View Toggle | Sort Type | Sort Mode */}
+                <HStack spacing={4}>
 
-              <Menu>
-                <MenuButton as={IconButton} icon={<SortIcon />} size="sm" variant="outline" />
-                <MenuList>
-                  <MenuItem onClick={() => setSortMode('name')}>
-                    <HStack><FiSearch /><Text>Name</Text></HStack>
-                  </MenuItem>
-                  <MenuItem onClick={() => setSortMode('rarity')}>
-                    <HStack><FiHash /><Text>Rarity</Text></HStack>
-                  </MenuItem>
-                  <MenuItem onClick={() => setSortMode('card_code')}>
-                    <HStack><FiType /><Text>Card Code</Text></HStack>
-                  </MenuItem>
-                  <MenuItem onClick={() => setSortMode('tags')}>
-                    <HStack><FiTag /><Text>Tags</Text></HStack>
-                  </MenuItem>
-                </MenuList>
-              </Menu>
-
-              <Tooltip label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}>
-                <IconButton
-                  icon={sortReverse ? <BsSortUp /> : <BsSortDown />}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setSortReverse(!sortReverse)}
-                  aria-label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}
-                />
-              </Tooltip>
-            </HStack>
-
-            {viewMode === 'thumbnails' && (
-              <HStack spacing={2}>
-                <Text fontSize="sm" color="gray.600" minW="60px">Size:</Text>
-                <Box width="120px">
-                  <Tooltip label={`Thumbnail size: ${thumbnailSize}px`}>
-                    <Slider
-                      value={thumbnailSize}
-                      onChange={setThumbnailSize}
-                      min={80}
-                      max={200}
-                      step={10}
+                  <Tooltip label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}>
+                    <IconButton
+                      icon={viewMode === 'list' ? <FaGripHorizontal /> : <FaGripLines />}
                       size="sm"
-                    >
-                      <SliderTrack>
-                        <SliderFilledTrack />
-                      </SliderTrack>
-                      <SliderThumb boxSize={3} />
-                    </Slider>
+                      variant="outline"
+                      onClick={() => setViewMode(viewMode === 'list' ? 'thumbnails' : 'list')}
+                      aria-label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}
+                    />
                   </Tooltip>
-                </Box>
-                <Text fontSize="sm" color="gray.500" minW="35px">{thumbnailSize}</Text>
+
+                  <Menu>
+                    <MenuButton as={IconButton} icon={<SortIcon />} size="sm" variant="outline" />
+                    <MenuList>
+                      <MenuItem onClick={() => setSortMode('name')}>
+                        <HStack><FiSearch /><Text>Name</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('rarity')}>
+                        <HStack><FiHash /><Text>Rarity</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('card_code')}>
+                        <HStack><FiType /><Text>Card Code</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('tags')}>
+                        <HStack><FiTag /><Text>Tags</Text></HStack>
+                      </MenuItem>
+                    </MenuList>
+                  </Menu>
+
+                  <Tooltip label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}>
+                    <IconButton
+                      icon={sortReverse ? <BsSortUp /> : <BsSortDown />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setSortReverse(!sortReverse)}
+                      aria-label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}
+                    />
+                  </Tooltip>
+                </HStack>
+
+                {/* Second row: Collection switches */}
+                {shouldShowCollectionFilters && (
+                  <HStack spacing={4}>
+                    <FormControl display="flex" alignItems="center">
+                      <FormLabel htmlFor="in-collection" mb="0" fontSize="sm">
+                        In Collection
+                      </FormLabel>
+                      <Switch
+                        id="in-collection"
+                        isChecked={inCollection}
+                        onChange={(e) => setInCollection(e.target.checked)}
+                        size="sm"
+                      />
+                    </FormControl>
+
+                    <FormControl display="flex" alignItems="center">
+                      <FormLabel htmlFor="show-proxies" mb="0" fontSize="sm">
+                        Show Proxies
+                      </FormLabel>
+                      <Switch
+                        id="show-proxies"
+                        isChecked={showProxies}
+                        onChange={(e) => setShowProxies(e.target.checked)}
+                        size="sm"
+
+                      />
+                    </FormControl>
+                  </HStack>
+                )}
+
+                {/* Third row: Thumbnail slider */}
+                {viewMode === 'thumbnails' && (
+                  <HStack spacing={2}>
+                    <Text fontSize="sm" color="gray.600" minW="60px">Size:</Text>
+                    <Box width="120px">
+                      <Tooltip label={`Thumbnail size: ${thumbnailSize}px`}>
+                        <Slider
+                          value={thumbnailSize}
+                          onChange={setThumbnailSize}
+                          min={80}
+                          max={200}
+                          step={10}
+                          size="sm"
+                        >
+                          <SliderTrack>
+                            <SliderFilledTrack />
+                          </SliderTrack>
+                          <SliderThumb boxSize={3} />
+                        </Slider>
+                      </Tooltip>
+                    </Box>
+                    <Text fontSize="sm" color="gray.500" minW="35px">{thumbnailSize}</Text>
+                  </HStack>
+                )}
+              </>
+            ) : (
+              // Desktop layout: Single row (original)
+              <HStack justify="space-between" align="center">
+                <HStack spacing={4}>
+                  <Tooltip label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}>
+                    <IconButton
+                      icon={viewMode === 'list' ? <FaGripHorizontal /> : <FaGripLines />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setViewMode(viewMode === 'list' ? 'thumbnails' : 'list')}
+                      aria-label={`Switch to ${viewMode === 'list' ? 'thumbnail' : 'list'} view`}
+                    />
+                  </Tooltip>
+
+                  <Menu>
+                    <MenuButton as={IconButton} icon={<SortIcon />} size="sm" variant="outline" />
+                    <MenuList>
+                      <MenuItem onClick={() => setSortMode('name')}>
+                        <HStack><FiSearch /><Text>Name</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('rarity')}>
+                        <HStack><FiHash /><Text>Rarity</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('card_code')}>
+                        <HStack><FiType /><Text>Card Code</Text></HStack>
+                      </MenuItem>
+                      <MenuItem onClick={() => setSortMode('tags')}>
+                        <HStack><FiTag /><Text>Tags</Text></HStack>
+                      </MenuItem>
+                    </MenuList>
+                  </Menu>
+
+                  <Tooltip label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}>
+                    <IconButton
+                      icon={sortReverse ? <BsSortUp /> : <BsSortDown />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setSortReverse(!sortReverse)}
+                      aria-label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}
+                    />
+                  </Tooltip>
+                </HStack>
+
+                {viewMode === 'thumbnails' && (
+                  <HStack spacing={2}>
+                    <Text fontSize="sm" color="gray.600" minW="60px">Size:</Text>
+                    <Box width="120px">
+                      <Tooltip label={`Thumbnail size: ${thumbnailSize}px`}>
+                        <Slider
+                          value={thumbnailSize}
+                          onChange={setThumbnailSize}
+                          min={80}
+                          max={200}
+                          step={10}
+                          size="sm"
+                        >
+                          <SliderTrack>
+                            <SliderFilledTrack />
+                          </SliderTrack>
+                          <SliderThumb boxSize={3} />
+                        </Slider>
+                      </Tooltip>
+                    </Box>
+                    <Text fontSize="sm" color="gray.500" minW="35px">{thumbnailSize}</Text>
+                  </HStack>
+                )}
+
+
+                {/* Collection-specific filters */}
+                {shouldShowCollectionFilters && (
+                  <HStack spacing={4}>
+                    <FormControl display="flex" alignItems="center">
+                      <FormLabel htmlFor="in-collection" mb="0" fontSize="sm">
+                        In Collection
+                      </FormLabel>
+                      <Switch
+                        id="in-collection"
+                        isChecked={inCollection}
+                        onChange={(e) => setInCollection(e.target.checked)}
+                        size="sm"
+                      />
+                    </FormControl>
+
+                    <FormControl display="flex" alignItems="center">
+                      <FormLabel htmlFor="show-proxies" mb="0" fontSize="sm">
+                        Show Proxies
+                      </FormLabel>
+                      <Switch
+                        id="show-proxies"
+                        isChecked={showProxies}
+                        onChange={(e) => setShowProxies(e.target.checked)}
+                        size="sm"
+                      />
+                    </FormControl>
+                  </HStack>
+                )}
               </HStack>
             )}
-
-            {/* Collection-specific filters */}
-            {shouldShowCollectionFilters && (
-              <HStack spacing={4}>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel htmlFor="in-collection" mb="0" fontSize="sm">
-                    In Collection
-                  </FormLabel>
-                  <Switch
-                    id="in-collection"
-                    isChecked={inCollection}
-                    onChange={(e) => setInCollection(e.target.checked)}
-                    size="sm"
-                  />
-                </FormControl>
-
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel htmlFor="show-proxies" mb="0" fontSize="sm">
-                    Show Proxies
-                  </FormLabel>
-                  <Switch
-                    id="show-proxies"
-                    isChecked={showProxies}
-                    onChange={(e) => setShowProxies(e.target.checked)}
-                    size="sm"
-                  />
-                </FormControl>
-              </HStack>
-            )}
-          </HStack>
+          </VStack>
         )}
       </VStack>
 

--- a/frontend/src/components/DeckHeader.js
+++ b/frontend/src/components/DeckHeader.js
@@ -14,7 +14,8 @@ import {
   MenuDivider,
   Badge,
   Flex,
-  Text
+  Text,
+  useBreakpointValue
 } from '@chakra-ui/react';
 import {
   ChevronDownIcon,
@@ -46,188 +47,380 @@ const DeckHeader = ({
   onImportDeck,
   onPublishDeck,
   onLocateDeck
-
 }) => {
+  // Check if we should use mobile layout
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
   return (
     <Box bg="white" p={4} borderRadius="lg" shadow="sm" border="1px" borderColor="gray.200">
-      <Flex justify="space-between" align="center">
-        {/* Left: Thumbnail and Name */}
-        <HStack spacing={4}>
-          {/* Deck Thumbnail - Updated to crop square from upper center */}
-          <Box
-            onClick={onThumbnailClick}
-            cursor="pointer"
-            _hover={{ opacity: 0.8 }}
-            transition="opacity 0.2s"
-          >
-            {deck.thumbnail ? (
-              <Box
-                width="80px"
-                height="80px"
-                borderRadius="md"
-                border="2px"
-                borderColor="transparent"
-                _hover={{ borderColor: 'blue.400' }}
-                transition="border-color 0.2s"
-                overflow="hidden"
-                position="relative"
-                bg="white"
-              >
-                <CardImage
-                  src={deck.thumbnail}
-                  alt="Deck thumbnail"
-                  width="160px"  // 2x the container width for zoom
-                  height="224px" // 2x the proportional height (80px * 2.8 aspect ratio)
-                  objectFit="cover"
-                  position="absolute"
-                  top="-20px"    // Focus on middle-top portion
-                  left="-40px"   // Center horizontally
-                />
-              </Box>
-            ) : (
-              <Box
-                width="80px"
-                height="80px"
-                bg="gray.200"
-                borderRadius="md"
-                border="2px"
-                borderColor="gray.300"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                _hover={{ bg: 'gray.300' }}
-                transition="background-color 0.2s"
-              >
-                <Text fontSize="xs" color="gray.600" textAlign="center" px={2}>
-                  Click to select thumbnail
+      {isMobile ? (
+        // Mobile layout: Stack vertically
+        <VStack spacing={4} align="stretch">
+          {/* First row: Thumbnail and Name */}
+          <HStack spacing={4}>
+            {/* Deck Thumbnail - Updated to crop square from upper center */}
+
+            <Box
+              onClick={onThumbnailClick}
+              cursor="pointer"
+              _hover={{ opacity: 0.8 }}
+              transition="opacity 0.2s"
+            >
+              {deck.thumbnail ? (
+                <Box
+
+                  width="80px"
+                  height="80px"
+                  borderRadius="md"
+                  border="2px"
+                  borderColor="transparent"
+                  _hover={{ borderColor: 'blue.400' }}
+                  transition="border-color 0.2s"
+                  overflow="hidden"
+                  position="relative"
+                  bg="white"
+                >
+                  <CardImage
+                    src={deck.thumbnail}
+                    alt="Deck thumbnail"
+                    width="160px"  // 2x the container width for zoom
+                    height="224px" // 2x the proportional height (80px * 2.8 aspect ratio)
+                    objectFit="cover"
+                    position="absolute"
+                    top="-20px"    // Focus on middle-top portion
+                    left="-40px"   // Center horizontally
+                  />
+                </Box>
+              ) : (
+                <Box
+                  width="80px"
+                  height="80px"
+
+                  bg="gray.200"
+                  borderRadius="md"
+                  border="2px"
+                  borderColor="gray.300"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  _hover={{ bg: 'gray.300' }}
+                  transition="background-color 0.2s"
+                >
+                  <Text fontSize="xs" color="gray.600" textAlign="center" px={2}>
+                    Click to select thumbnail
+                  </Text>
+                </Box>
+              )}
+            </Box>
+
+            <VStack align="start" spacing={2} flex="1">
+              <Input
+                value={deck.name}
+                onChange={(e) => onNameChange(e.target.value)}
+                fontWeight="bold"
+
+                fontSize="lg"
+                variant="unstyled"
+                placeholder="Deck Name"
+                _placeholder={{ color: 'gray.400' }}
+              />
+              <HStack spacing={4}>
+                <Text fontSize="sm" color="gray.600">
+                  {stats.cardCount}/50 cards
                 </Text>
-              </Box>
-            )}
-          </Box>
+                {!stats.hasLeader && (
+                  <Badge colorScheme="red" variant="subtle">
+                    No Leader
+                  </Badge>
+                )}
+                {stats.hasColorMismatch && (
+                  <Badge colorScheme="orange" variant="subtle">
+                    Color Mismatch
+                  </Badge>
+                )}
+                {stats.hasBannedCard && (
+                  <Badge colorScheme="red" variant="solid">
+                    Banned
+                  </Badge>
+                )}
+              </HStack>
+            </VStack>
+          </HStack>
 
-          <VStack align="start" spacing={2}>
-            <Input
-              value={deck.name}
-              onChange={(e) => onNameChange(e.target.value)}
-              fontWeight="bold"
-              fontSize="lg"
-              variant="unstyled"
-              placeholder="Deck Name"
-              _placeholder={{ color: 'gray.400' }}
-            />
-            <HStack spacing={4}>
-              <Text fontSize="sm" color="gray.600">
-                {stats.cardCount}/50 cards
-              </Text>
-              {!stats.hasLeader && (
-                <Badge colorScheme="red" variant="subtle">
-                  No Leader
-                </Badge>
-              )}
-              {stats.hasColorMismatch && (
-                <Badge colorScheme="orange" variant="subtle">
-                  Color Mismatch
-                </Badge>
-              )}
-              {stats.hasBannedCard && (
-                <Badge colorScheme="red" variant="solid">
-                  Banned
-                </Badge>
-              )}
-            </HStack>
-          </VStack>
-        </HStack>
-
-        {/* Right: Actions */}
-        <HStack spacing={2}>
-          {/* Clear - Standalone */}
-          <Button
-
-            leftIcon={<RepeatIcon />}
-            size="sm"
-            variant="outline"
-            onClick={onClearDeck}
-            colorScheme="gray"
-          >
-            Clear
-          </Button>
-
-          {/* Tools Menu */}
-          <Menu>
-            <MenuButton
-              as={Button}
-              rightIcon={<ChevronDownIcon />}
-              leftIcon={<FiSettings />}
+          {/* Second row: Action buttons */}
+          <HStack spacing={2} justify="stretch">
+            {/* Clear - Standalone */}
+            <Button
+              leftIcon={<RepeatIcon />}
               size="sm"
               variant="outline"
+              onClick={onClearDeck}
+              colorScheme="gray"
+              flex="1"
             >
-              Tools
-            </MenuButton>
-            <MenuList>
-              <MenuItem onClick={onLoadDeck} icon={<FiDownload />}>
-                Load
-              </MenuItem>
-              <MenuItem onClick={onSaveDeck} icon={<FiSave />}>
-                Save
-              </MenuItem>
-              <MenuDivider />
-              <MenuItem onClick={onLocateDeck || (() => {})} icon={<FiMapPin />}>
-                Locate
-              </MenuItem>
-              <MenuDivider />
-              <MenuItem
-                onClick={onImportDeck || (() => {})}
-                icon={<FiUpload />}
-                isDisabled={!onImportDeck}
-              >
-                Import
-              </MenuItem>
-              <MenuDivider />
-              <MenuItem
-                onClick={onDeleteDeck}
-                icon={<FiTrash2 />}
-                color="red.600"
-                isDisabled={!deck.id}
-              >
-                Delete
-              </MenuItem>
-            </MenuList>
-          </Menu>
+              Clear
+            </Button>
 
-          {/* Share Menu */}
-          <Menu>
-            <MenuButton
-              as={Button}
-              rightIcon={<ChevronDownIcon />}
-              leftIcon={<FiShare2 />}
+            {/* Tools Menu */}
+            <Menu>
+              <MenuButton
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+                leftIcon={<FiSettings />}
+                size="sm"
+                variant="outline"
+                flex="1"
+              >
+                Tools
+              </MenuButton>
+              <MenuList>
+                <MenuItem onClick={onLoadDeck} icon={<FiDownload />}>
+                  Load
+                </MenuItem>
+                <MenuItem onClick={onSaveDeck} icon={<FiSave />}>
+                  Save
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem onClick={onLocateDeck || (() => {})} icon={<FiMapPin />}>
+                  Locate
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onImportDeck || (() => {})}
+                  icon={<FiUpload />}
+                  isDisabled={!onImportDeck}
+                >
+                  Import
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onDeleteDeck}
+                  icon={<FiTrash2 />}
+                  color="red.600"
+                  isDisabled={!deck.id}
+                >
+                  Delete
+                </MenuItem>
+              </MenuList>
+            </Menu>
+
+            {/* Share Menu */}
+            <Menu>
+              <MenuButton
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+                leftIcon={<FiShare2 />}
+                size="sm"
+                variant="outline"
+                colorScheme="blue"
+                isDisabled={!deck.cards || deck.cards.length === 0}
+                flex="1"
+              >
+                Share
+              </MenuButton>
+              <MenuList>
+                <MenuItem
+                  onClick={onPublishDeck || (() => {})}
+                  icon={<FiGlobe />}
+                  isDisabled={!stats.hasLeader}
+                >
+                  Publish
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onShareDeckList}
+                  icon={<FiCopy />}
+
+                  isDisabled={!deck.cards || deck.cards.length === 0}
+                >
+                  Copy Deck List
+                </MenuItem>
+              </MenuList>
+            </Menu>
+          </HStack>
+        </VStack>
+      ) : (
+        // Desktop layout: Original horizontal layout
+        <Flex justify="space-between" align="center">
+          {/* Left: Thumbnail and Name */}
+          <HStack spacing={4}>
+            {/* Deck Thumbnail - Updated to crop square from upper center */}
+            <Box
+              onClick={onThumbnailClick}
+              cursor="pointer"
+              _hover={{ opacity: 0.8 }}
+              transition="opacity 0.2s"
+            >
+              {deck.thumbnail ? (
+                <Box
+                  width="80px"
+                  height="80px"
+                  borderRadius="md"
+                  border="2px"
+                  borderColor="transparent"
+                  _hover={{ borderColor: 'blue.400' }}
+                  transition="border-color 0.2s"
+                  overflow="hidden"
+                  position="relative"
+                  bg="white"
+                >
+                  <CardImage
+                    src={deck.thumbnail}
+                    alt="Deck thumbnail"
+                    width="160px"  // 2x the container width for zoom
+                    height="224px" // 2x the proportional height (80px * 2.8 aspect ratio)
+                    objectFit="cover"
+                    position="absolute"
+                    top="-20px"    // Focus on middle-top portion
+                    left="-40px"   // Center horizontally
+                  />
+                </Box>
+              ) : (
+                <Box
+                  width="80px"
+                  height="80px"
+                  bg="gray.200"
+                  borderRadius="md"
+                  border="2px"
+                  borderColor="gray.300"
+                  display="flex"
+
+                  alignItems="center"
+                  justifyContent="center"
+                  _hover={{ bg: 'gray.300' }}
+                  transition="background-color 0.2s"
+                >
+                  <Text fontSize="xs" color="gray.600" textAlign="center" px={2}>
+                    Click to select thumbnail
+                  </Text>
+                </Box>
+              )}
+            </Box>
+
+            <VStack align="start" spacing={2}>
+              <Input
+                value={deck.name}
+                onChange={(e) => onNameChange(e.target.value)}
+                fontWeight="bold"
+                fontSize="lg"
+                variant="unstyled"
+                placeholder="Deck Name"
+                _placeholder={{ color: 'gray.400' }}
+              />
+              <HStack spacing={4}>
+                <Text fontSize="sm" color="gray.600">
+                  {stats.cardCount}/50 cards
+                </Text>
+                {!stats.hasLeader && (
+                  <Badge colorScheme="red" variant="subtle">
+                    No Leader
+                  </Badge>
+                )}
+                {stats.hasColorMismatch && (
+                  <Badge colorScheme="orange" variant="subtle">
+                    Color Mismatch
+                  </Badge>
+                )}
+                {stats.hasBannedCard && (
+                  <Badge colorScheme="red" variant="solid">
+                    Banned
+                  </Badge>
+                )}
+              </HStack>
+            </VStack>
+          </HStack>
+
+          {/* Right: Actions */}
+          <HStack spacing={2}>
+            {/* Clear - Standalone */}
+            <Button
+              leftIcon={<RepeatIcon />}
               size="sm"
               variant="outline"
-              colorScheme="blue"
-              isDisabled={!deck.cards || deck.cards.length === 0}
+              onClick={onClearDeck}
+              colorScheme="gray"
             >
-              Share
-            </MenuButton>
-            <MenuList>
-              <MenuItem
-                onClick={onPublishDeck || (() => {})}
-                icon={<FiGlobe />}
+              Clear
+            </Button>
 
-                isDisabled={!stats.hasLeader}
+            {/* Tools Menu */}
+            <Menu>
+              <MenuButton
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+                leftIcon={<FiSettings />}
+                size="sm"
+                variant="outline"
               >
-                Publish
-              </MenuItem>
-              <MenuDivider />
-              <MenuItem
-                onClick={onShareDeckList}
-                icon={<FiCopy />}
+                Tools
+              </MenuButton>
+              <MenuList>
+                <MenuItem onClick={onLoadDeck} icon={<FiDownload />}>
+                  Load
+                </MenuItem>
+                <MenuItem onClick={onSaveDeck} icon={<FiSave />}>
+                  Save
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem onClick={onLocateDeck || (() => {})} icon={<FiMapPin />}>
+                  Locate
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onImportDeck || (() => {})}
+                  icon={<FiUpload />}
+                  isDisabled={!onImportDeck}
+                >
+                  Import
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onDeleteDeck}
+                  icon={<FiTrash2 />}
+                  color="red.600"
+                  isDisabled={!deck.id}
+                >
+                  Delete
+                </MenuItem>
+              </MenuList>
+            </Menu>
+
+
+            {/* Share Menu */}
+            <Menu>
+              <MenuButton
+                as={Button}
+                rightIcon={<ChevronDownIcon />}
+                leftIcon={<FiShare2 />}
+                size="sm"
+                variant="outline"
+                colorScheme="blue"
                 isDisabled={!deck.cards || deck.cards.length === 0}
               >
-                Copy Deck List
-              </MenuItem>
-            </MenuList>
-          </Menu>
-        </HStack>
-      </Flex>
+                Share
+              </MenuButton>
+              <MenuList>
+                <MenuItem
+                  onClick={onPublishDeck || (() => {})}
+                  icon={<FiGlobe />}
+                  isDisabled={!stats.hasLeader}
+                >
+                  Publish
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onShareDeckList}
+                  icon={<FiCopy />}
+                  isDisabled={!deck.cards || deck.cards.length === 0}
+                >
+                  Copy Deck List
+
+                </MenuItem>
+              </MenuList>
+            </Menu>
+          </HStack>
+        </Flex>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/DeckViewerCanvas.js
+++ b/frontend/src/components/DeckViewerCanvas.js
@@ -37,7 +37,8 @@ import {
   Tr,
   Th,
   Td,
-  Circle
+  Circle,
+  useBreakpointValue
 } from '@chakra-ui/react';
 
 import { BsSortUp, BsSortDown } from 'react-icons/bs';
@@ -103,6 +104,9 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
   const { isOpen: isCardDetailOpen, onOpen: onCardDetailOpen, onClose: onCardDetailClose } = useDisclosure();
   const [selectedCardForDetail, setSelectedCardForDetail] = useState(null);
 
+  // Check if we should use mobile layout for controls
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
   const colorScheme = playerNumber === 1 ? 'blue' : 'red';
 
   // Calculate deck statistics
@@ -125,10 +129,10 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
 
     let totalCards = 0;
     let leader = null;
-    const costDist = {};
-    const colorDist = {};
-    const categoryDist = {};
-    const keywordCounts = {};
+    let costDist = {};
+    let colorDist = {};
+    let categoryDist = {};
+    let keywordCounts = {};
     let totalCounterValue = 0;
     let cardsWithCounters = 0;
     let counter1K = 0;
@@ -136,56 +140,47 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
 
     deck.cards.forEach(item => {
       const cardData = getCardData(item);
-      if (!cardData) return;
+      const count = item.count || 1;
+      totalCards += count;
 
-      totalCards += item.count;
-
-      // Count by category
-      const category = cardData.category || 'Unknown';
-      categoryDist[category] = (categoryDist[category] || 0) + item.count;
-
-      // Check for leader
-      if (category === 'LEADER') {
+      if (cardData?.category === 'LEADER') {
         leader = cardData;
       }
 
-      // Count by cost (only for non-leaders)
-      if (category !== 'LEADER') {
-        const cost = cardData.cost || 0;
-        costDist[cost] = (costDist[cost] || 0) + item.count;
+      // Cost distribution
+      const cost = cardData?.cost || 0;
+      costDist[cost] = (costDist[cost] || 0) + count;
+
+      // Color distribution
+      if (cardData?.color) {
+        colorDist[cardData.color] = (colorDist[cardData.color] || 0) + count;
       }
 
-      // Count by color
-      if (cardData.color) {
-        const colors = cardData.color.split('/');
-        colors.forEach(color => {
-          const cleanColor = color.trim();
-          colorDist[cleanColor] = (colorDist[cleanColor] || 0) + item.count;
+      // Category distribution
+      if (cardData?.category) {
+        categoryDist[cardData.category] = (categoryDist[cardData.category] || 0) + count;
+      }
+
+      // Counter values
+      if (cardData?.counter) {
+        totalCounterValue += cardData.counter * count;
+        cardsWithCounters += count;
+
+        if (cardData.counter === 1000) counter1K += count;
+        if (cardData.counter === 2000) counter2K += count;
+      }
+
+      // Extract keywords from effect text
+      if (cardData?.effect || cardData?.trigger_effect) {
+        const cardKeywords = extractStyledKeywords(cardData.effect, cardData.trigger_effect);
+        Object.entries(cardKeywords).forEach(([keyword, keywordCount]) => {
+          keywordCounts[keyword] = (keywordCounts[keyword] || 0) + (keywordCount * count);
         });
       }
-
-      // Calculate counter values (excluding leaders)
-      if (category !== 'LEADER' && cardData.counter) {
-        totalCounterValue += cardData.counter * item.count;
-        cardsWithCounters += item.count;
-
-        // Count specific counter values
-        if (cardData.counter === 1000) {
-          counter1K += item.count;
-        }
-        if (cardData.counter === 2000) {
-          counter2K += item.count;
-        }
-      }
-
-      // Extract keywords from each card
-      const cardKeywords = extractStyledKeywords(cardData.effect, cardData.trigger_effect);
-      Object.entries(cardKeywords).forEach(([keyword, count]) => {
-        keywordCounts[keyword] = (keywordCounts[keyword] || 0) + (count * item.count);
-      });
     });
 
-    const averageCounterValue = cardsWithCounters > 0 ? (totalCounterValue / cardsWithCounters).toFixed(1) : 0;
+    const averageCounterValue = cardsWithCounters > 0 ?
+      (totalCounterValue / cardsWithCounters).toFixed(1) : 0;
 
     return {
       totalCards,
@@ -338,63 +333,50 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
             Empty deck
           </Text>
           <Text color="gray.400" fontSize="sm">
-            This deck contains no cards
+            This deck has no cards
           </Text>
         </VStack>
       </Box>
     );
   }
 
-  // Prepare data for charts
-  const costChartData = Object.entries(stats.costDistribution)
-    .sort(([a], [b]) => parseInt(a) - parseInt(b))
-    .map(([cost, count]) => ({
-      cost: parseInt(cost),
-      count,
-      name: `${cost}`
-    }));
-
-  // Add missing cost values with 0 count for better visualization
-  const maxCost = Math.max(...costChartData.map(d => d.cost), 10);
-  const fullCostData = [];
-  for (let i = 0; i <= maxCost; i++) {
-    const existing = costChartData.find(d => d.cost === i);
-    fullCostData.push(existing || { cost: i, count: 0, name: i.toString() });
-  }
-  // Add 10+ category if there are cards with cost > 10
-  const highCostCount = Object.entries(stats.costDistribution)
-    .filter(([cost]) => parseInt(cost) > 10)
-    .reduce((sum, [, count]) => sum + count, 0);
-  if (highCostCount > 0) {
-    fullCostData.push({ cost: 11, count: highCostCount, name: '10+' });
-  }
-
-  const colorChartData = Object.entries(stats.colorDistribution).map(([color, count]) => {
-    const hexColor = getColorHex(color);
-    return {
-      name: getColorName(color),
-      value: count,
-      fill: hexColor
-    };
-  });
-
   return (
     <VStack spacing={4} align="stretch" h="100%">
-      <Tabs defaultIndex={0}>
+      <HStack justify="space-between" align="center">
+        <VStack align="start" spacing={1}>
+          <Text fontSize="lg" fontWeight="bold" color={`${colorScheme}.600`}>
+            {deck.name || `Player ${playerNumber} Deck`}
+          </Text>
+          <Text fontSize="sm" color="gray.600">
+            {stats.totalCards} cards • {stats.hasLeader ? 'Has leader' : 'No leader'}
+          </Text>
+        </VStack>
+        <Badge
+          colorScheme={colorScheme}
+          variant="subtle"
+          fontSize="sm"
+          px={3}
+          py={1}
+          borderRadius="full"
+        >
+          Player {playerNumber}
+        </Badge>
+      </HStack>
+      <Tabs variant="enclosed" colorScheme={colorScheme} flex="1">
         <TabList>
-          <Tab>Deck</Tab>
-          <Tab>Statistics</Tab>
+          <Tab>Cards</Tab>
+          <Tab>Stats</Tab>
           <Tab>Keywords</Tab>
         </TabList>
 
         <TabPanels>
           <TabPanel>
-            {/* Compact Controls - All in one line */}
-            <HStack justify="space-between" align="center" mb={4} spacing={4}>
-              {/* Left side - Size and Sort controls */}
-              <HStack spacing={4} flex={1}>
-                {/* Thumbnail Size Slider - Compact */}
-                <HStack spacing={2} minW="200px">
+            {/* Compact Controls - Responsive Layout */}
+            {isMobile ? (
+              // Mobile layout: Two rows
+              <VStack spacing={3} align="stretch" mb={4}>
+                {/* First row: Thumbnail Size Slider */}
+                <HStack spacing={2}>
                   <Text fontSize="sm" color="gray.600" minW="60px">Size:</Text>
                   <Slider
                     value={thumbnailSize}
@@ -402,7 +384,7 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
                     min={80}
                     max={200}
                     step={10}
-                    width="120px"
+                    flex="1"
                   >
                     <SliderTrack>
                       <SliderFilledTrack />
@@ -412,14 +394,14 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
                   <Text fontSize="sm" color="gray.500" minW="35px">{thumbnailSize}</Text>
                 </HStack>
 
-                {/* Sort Controls - Compact */}
+                {/* Second row: Sort Controls */}
                 <HStack spacing={2}>
-                  <Text fontSize="sm" color="gray.600">Sort:</Text>
+                  <Text fontSize="sm" color="gray.600" minW="60px">Sort:</Text>
                   <Select
                     size="sm"
                     value={sortMode}
                     onChange={(e) => setSortMode(e.target.value)}
-                    width="100px"
+                    flex="1"
                   >
                     <option value="cost">Cost</option>
                     <option value="name">Name</option>
@@ -434,14 +416,66 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
                       size="sm"
                       variant="outline"
                       onClick={() => setSortReverse(!sortReverse)}
+                      flexShrink={0}
                     />
                   </Tooltip>
                 </HStack>
-              </HStack>
+              </VStack>
+            ) : (
+              // Desktop layout: Original single row
+              <HStack justify="space-between" align="center" mb={4} spacing={4}>
+                {/* Left side - Size and Sort controls */}
+                <HStack spacing={4} flex={1}>
+                  {/* Thumbnail Size Slider - Compact */}
+                  <HStack spacing={2} minW="200px">
+                    <Text fontSize="sm" color="gray.600" minW="60px">Size:</Text>
+                    <Slider
+                      value={thumbnailSize}
+                      onChange={setThumbnailSize}
+                      min={80}
+                      max={200}
+                      step={10}
+                      width="120px"
+                    >
+                      <SliderTrack>
+                        <SliderFilledTrack />
+                      </SliderTrack>
+                      <SliderThumb boxSize={4} />
+                    </Slider>
+                    <Text fontSize="sm" color="gray.500" minW="35px">{thumbnailSize}</Text>
+                  </HStack>
 
-              {/* Right side - Empty for cleaner layout */}
-              <Box></Box>
-            </HStack>
+                  {/* Sort Controls - Compact */}
+                  <HStack spacing={2}>
+                    <Text fontSize="sm" color="gray.600">Sort:</Text>
+                    <Select
+                      size="sm"
+                      value={sortMode}
+
+                      onChange={(e) => setSortMode(e.target.value)}
+                      width="100px"
+                    >
+                      <option value="cost">Cost</option>
+                      <option value="name">Name</option>
+                      <option value="category">Category</option>
+                      <option value="color">Color</option>
+                      <option value="count">Count</option>
+                    </Select>
+                    <Tooltip label={sortReverse ? 'Sort ascending' : 'Sort descending'}>
+                      <IconButton
+                        icon={sortReverse ? <BsSortUp /> : <BsSortDown />}
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setSortReverse(!sortReverse)}
+                      />
+                    </Tooltip>
+                  </HStack>
+                </HStack>
+
+                {/* Right side - Empty for cleaner layout */}
+                <Box></Box>
+              </HStack>
+            )}
 
             {/* Cards Grid */}
             <Box
@@ -502,155 +536,62 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
                       Statistics
                     </Text>
                     <Badge colorScheme={stats.hasLeader ? 'green' : 'red'} variant="subtle">
-                      {stats.hasLeader ? 'Has Leader' : 'No Leader'}
+                      {stats.hasLeader ? 'Valid' : 'No Leader'}
                     </Badge>
                   </HStack>
-
+                  {/* Basic Stats */}
                   <StatGroup>
                     <Stat>
-                      <StatLabel fontSize="xs">Total Cards</StatLabel>
-                      <StatNumber fontSize="md">{stats.totalCards}</StatNumber>
+                      <StatLabel>Total Cards</StatLabel>
+                      <StatNumber>{stats.totalCards}</StatNumber>
                     </Stat>
                     <Stat>
-                      <StatLabel fontSize="xs">Unique Cards</StatLabel>
-                      <StatNumber fontSize="md">{stats.uniqueCards}</StatNumber>
+                      <StatLabel>Unique Cards</StatLabel>
+                      <StatNumber>{stats.uniqueCards}</StatNumber>
+                    </Stat>
+                    <Stat>
+                      <StatLabel>Avg Counter</StatLabel>
+                      <StatNumber>{stats.averageCounterValue}</StatNumber>
                     </Stat>
                   </StatGroup>
 
-                  {/* Counter Statistics - Badge Style */}
-                  <Box>
-                    <Text fontSize="xs" fontWeight="medium" color="gray.600" mb={2}>
-                      Counter Stats
-                    </Text>
-                    <HStack spacing={2} flexWrap="wrap">
-                      <Badge
-                        colorScheme="blackAlpha"
-                        bg="black"
-                        color="white"
-                        variant="solid"
-                        px={3}
-                        py={1}
-                        borderRadius="full"
-                        fontSize="sm"
-                      >
-                        ⚡ Avg: {stats.averageCounterValue}k / card
-                      </Badge>
-                      {stats.counter2K > 0 && (
-                        <Badge
-                          colorScheme="gray"
-                          variant="solid"
-                          px={3}
-                          py={1}
-                          borderRadius="full"
-                          fontSize="sm"
-                        >
-                          2k: {stats.counter2K}
-                        </Badge>
-                      )}
-                      {stats.counter1K > 0 && (
-                        <Badge
-                          colorScheme="gray"
-                          variant="solid"
-                          px={3}
-                          py={1}
-                          borderRadius="full"
-                          fontSize="sm"
-                        >
-                          1k: {stats.counter1K}
-                        </Badge>
-                      )}
-                    </HStack>
-                  </Box>
-
-                  {/* Cost Distribution Bar Chart */}
-                  {fullCostData.length > 0 && fullCostData.some(d => d.count > 0) && (
+                  {/* Cost Distribution Chart */}
+                  {Object.keys(stats.costDistribution).length > 0 && (
                     <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color="gray.700" mb={3}>
-                        Cost Curve
+                      <Text fontSize="xs" fontWeight="medium" color="gray.600" mb={2}>
+                        Cost Distribution
                       </Text>
-                      <Box h="300px" bg="white" borderRadius="lg" p={4} border="1px solid" borderColor="gray.200">
+                      <Box h="120px">
                         <ResponsiveContainer width="100%" height="100%">
-                          <BarChart
-                            data={fullCostData}
-                            margin={{ top: 20, right: 30, left: 20, bottom: 40 }}
-                            barCategoryGap="10%"
-                          >
-                            <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
-                            <XAxis
-                              dataKey="name"
-                              fontSize={8}
-                              stroke="#2D3748"
-                              tick={{ fill: '#2D3748' }}
-                              axisLine={{ stroke: '#A0AEC0' }}
-                              tickLine={{ stroke: '#A0AEC0' }}
-                            />
-                            <YAxis
-                              fontSize={8}
-                              stroke="#2D3748"
-                              tick={{ fill: '#2D3748' }}
-                              axisLine={{ stroke: '#A0AEC0' }}
-                              tickLine={{ stroke: '#A0AEC0' }}
-                              label={{ value: 'Count', angle: -90, position: 'insideLeft', style: { textAnchor: 'middle', fill: '#2D3748' } }}
-                            />
-                            <Bar
-                              dataKey="count"
-                              fill="#1A202C"
-                              radius={[4, 4, 0, 0]}
-                              label={{
-                                position: 'top',
-                                fontSize: 8,
-                                fill: '#2D3748',
-                                formatter: (value) => value > 0 ? value : ''
-                              }}
-                            />
+                          <BarChart data={Object.entries(stats.costDistribution).map(([cost, count]) => ({
+                            cost: cost === '0' ? '0' : cost,
+                            count
+                          }))}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="cost" />
+                            <YAxis />
+                            <Bar dataKey="count" fill={colorScheme === 'blue' ? '#3182ce' : '#e53e3e'} />
                           </BarChart>
                         </ResponsiveContainer>
                       </Box>
                     </Box>
                   )}
 
-                  {/* Color Distribution Pie Chart */}
-                  {colorChartData.length > 0 && (
-                    <Box>
-                      <Text fontSize="xs" fontWeight="medium" color="gray.600" mb={2}>
-                        Color Distribution
-                      </Text>
-                      <Box h="200px">
-                        <ResponsiveContainer width="100%" height="100%">
-                          <PieChart>
-                            <Pie
-                              data={colorChartData}
-                              cx="50%"
-                              cy="50%"
-                              innerRadius={30}
-                              outerRadius={80}
-                              paddingAngle={2}
-                              dataKey="value"
-                              label={({ name, value }) => `${name}: ${value}`}
-                              labelStyle={{ fontSize: 7, fill: '#2D3748' }}
-                            >
-                              {colorChartData.map((entry, index) => (
-                                <Cell key={`cell-${index}`} fill={entry.fill} />
-                              ))}
-                            </Pie>
-                          </PieChart>
-                        </ResponsiveContainer>
-                      </Box>
-                    </Box>
-                  )}
-
-                  {/* Category Distribution */}
-                  {Object.keys(stats.categoryDistribution).length > 0 && (
+                  {/* Color Distribution */}
+                  {Object.keys(stats.colorDistribution).length > 0 && (
                     <Box>
                       <Text fontSize="xs" fontWeight="medium" color="gray.600" mb={1}>
-                        Category Distribution
+                        Colors
                       </Text>
                       <Wrap spacing={1}>
-                        {Object.entries(stats.categoryDistribution).map(([category, count]) => (
-                          <WrapItem key={category}>
-                            <Tag size="sm" variant="outline" borderColor="black" color="black">
-                              <TagLabel>{category}: {count}</TagLabel>
-                            </Tag>
+                        {Object.entries(stats.colorDistribution).map(([color, count]) => (
+                          <WrapItem key={color}>
+                            <HStack spacing={2}>
+                              <Circle size="12px" bg={getColorHex(color)} />
+                              <Tag size="sm" variant="outline">
+                                <TagLabel>{getColorName(color)}: {count}</TagLabel>
+                              </Tag>
+                            </HStack>
                           </WrapItem>
                         ))}
                       </Wrap>
@@ -684,94 +625,86 @@ const DeckViewerCanvas = ({ deck, showStats = true, playerNumber = 1 }) => {
           <TabPanel>
             {/* Keywords - List Layout */}
             {Object.keys(stats.keywordCounts).length > 0 && sortedCards.length > 0 ? (
-              <VStack spacing={6} align="stretch">
+              <VStack spacing={4} align="stretch">
                 {Object.entries(stats.keywordCounts)
                   .filter(([keyword, count]) => count > 0)
                   .sort(([a], [b]) => a.localeCompare(b))
-                  .map(([keyword, totalCount]) => {
-                    // Find all cards that have this keyword
+                  .map(([keyword, count]) => {
+                    // Find cards with this keyword
                     const cardsWithKeyword = sortedCards.filter(item => {
                       const cardData = getCardData(item);
-                      if (!cardData) return false;
-                      const cardKeywords = extractStyledKeywords(cardData.effect, cardData.trigger_effect);
-                      return cardKeywords[keyword] && cardKeywords[keyword] > 0;
+                      const cardKeywords = extractStyledKeywords(cardData?.effect, cardData?.trigger_effect);
+                      return cardKeywords[keyword] > 0;
                     });
 
-                    if (cardsWithKeyword.length === 0) return null;
-
                     return (
-                      <Box key={keyword}>
-                        <HStack mb={3} align="center">
-                          <Text fontSize="lg" fontWeight="bold" color="gray.700">
-                            • Cards with
-                          </Text>
+                      <Box key={keyword} bg="white" p={3} borderRadius="md" border="1px" borderColor="gray.200">
+                        <VStack align="stretch" spacing={2}>
+                          <HStack justify="space-between">
+                            <Tag size="md" variant="outline" borderColor="black" color="black">
+                              <TagLabel fontWeight="semibold">{keyword}</TagLabel>
+                            </Tag>
+                            <Badge colorScheme="gray">{count} total</Badge>
+                          </HStack>
 
-                          <StyledTextRenderer text={`[${keyword}]`} />
-                          <Text fontSize="lg" fontWeight="bold" color="gray.700">
-                            ({totalCount} total)
-                          </Text>
-                        </HStack>
-                        <Wrap spacing={3}>
-                          {cardsWithKeyword.map((item, index) => {
-
-                            const cardData = getCardData(item);
-                            if (!cardData) return null;
-
-                            return (
-                              <WrapItem key={`${cardData.id}-${index}`}>
-                                <Box
-                                  position="relative"
-                                  cursor="pointer"
-                                  onClick={() => handleCardClick(item)}
-                                  _hover={{ transform: 'scale(1.05)' }}
-                                  transition="transform 0.2s"
-                                >
-                                  <Image
-                                    src={cardData.img_url || '/placeholder.png'}
-                                    alt={cardData.name || 'Card'}
-                                    width="60px"
-                                    height="84px"
-                                    objectFit="cover"
-                                    borderRadius="sm"
-                                    border={cardData.category === 'LEADER' ?
-                                      '2px solid gold' : '1px solid gray'}
-                                  />
-                                  {/* Card count badge */}
-                                  <Badge
-                                    position="absolute"
-                                    top="-8px"
-                                    right="-8px"
-                                    colorScheme="blue"
-                                    variant="solid"
-                                    borderRadius="full"
-                                    fontSize="xs"
-                                    minW="20px"
-                                    textAlign="center"
+                          <Wrap spacing={2}>
+                            {cardsWithKeyword.map((item, index) => {
+                              const cardData = getCardData(item);
+                              return (
+                                <WrapItem key={`${cardData?.id}-${index}`}>
+                                  <Box
+                                    position="relative"
+                                    cursor="pointer"
+                                    onClick={() => handleCardClick(item)}
+                                    _hover={{ transform: 'scale(1.05)' }}
+                                    transition="transform 0.2s"
                                   >
-                                    {item.count}
-                                  </Badge>
-                                  {/* Card name tooltip */}
-                                  <Tooltip label={cardData.name} placement="top">
-                                    <Box
+                                    <Image
+                                      src={cardData?.image_url}
+                                      alt={cardData?.name}
+                                      width="60px"
+                                      height="84px"
+                                      objectFit="cover"
+                                      borderRadius="sm"
+                                      border={cardData?.category === 'LEADER' ? '2px solid gold' : '1px solid gray'}
+                                    />
+                                    {/* Card count badge */}
+                                    <Badge
                                       position="absolute"
-                                      bottom="0"
-                                      left="0"
-                                      right="0"
-                                      bg="blackAlpha.700"
-                                      color="white"
+                                      top="-8px"
+                                      right="-8px"
+                                      colorScheme="blue"
+                                      variant="solid"
+                                      borderRadius="full"
                                       fontSize="xs"
-                                      p={1}
+                                      minW="20px"
                                       textAlign="center"
-                                      borderBottomRadius="sm"
                                     >
-                                      <Text noOfLines={1}>{cardData.name}</Text>
-                                    </Box>
-                                  </Tooltip>
-                                </Box>
-                              </WrapItem>
-                            );
-                          })}
-                        </Wrap>
+                                      {item.count}
+                                    </Badge>
+                                    {/* Card name tooltip */}
+                                    <Tooltip label={cardData.name} placement="top">
+                                      <Box
+                                        position="absolute"
+                                        bottom="0"
+                                        left="0"
+                                        right="0"
+                                        bg="blackAlpha.700"
+                                        color="white"
+                                        fontSize="xs"
+                                        p={1}
+                                        textAlign="center"
+                                        borderBottomRadius="sm"
+                                      >
+                                        <Text noOfLines={1}>{cardData.name}</Text>
+                                      </Box>
+                                    </Tooltip>
+                                  </Box>
+                                </WrapItem>
+                              );
+                            })}
+                          </Wrap>
+                        </VStack>
                       </Box>
                     );
                   })}

--- a/frontend/src/components/MatchUpComponent.js
+++ b/frontend/src/components/MatchUpComponent.js
@@ -21,6 +21,7 @@ import {
   useColorModeValue,
   Collapse
 } from '@chakra-ui/react';
+
 import { AddIcon, RepeatIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 import { useSearchParams } from 'next/navigation';
 import SelectDeckModal from '@/components/SelectDeckModal';
@@ -45,7 +46,6 @@ const parseDeckContent = async (deckContent) => {
       throw new Error('Failed to parse deck content');
     }
 
-
     const parsedDeck = await response.json();
     return parsedDeck;
   } catch (error) {
@@ -58,6 +58,7 @@ const parseDeckContent = async (deckContent) => {
 const generateDeckContent = (deck) => {
   if (!deck?.cards || !Array.isArray(deck.cards) || deck.cards.length === 0) {
     return '';
+
   }
 
   return deck.cards
@@ -72,6 +73,7 @@ const generateDeckContent = (deck) => {
 const MatchUpComponent = () => {
   const searchParams = useSearchParams();
   const toast = useToast();
+
 
   const [deck1, setDeck1] = useState({ name: '', cards: [], type: null });
   const [deck2, setDeck2] = useState({ name: '', cards: [], type: null });
@@ -101,7 +103,6 @@ const MatchUpComponent = () => {
     setPowerCounters(prev => {
       const newCounters = [...prev];
       newCounters[index] = 0;
-
       return newCounters;
     });
   };
@@ -118,12 +119,14 @@ const MatchUpComponent = () => {
     lg: 6
   });
 
+  // Check if we should use mobile layout (wrap player info to multiple lines)
+  const isMobile = useBreakpointValue({ base: true, sm: false });
+
   // Load decks from URL parameters on mount
   useEffect(() => {
     const deckParams = searchParams.getAll('deck');
 
     if (deckParams.length > 0) {
-
       // Load first deck
       if (deckParams[0]) {
         loadDeckFromContent(deckParams[0], 1);
@@ -240,7 +243,6 @@ const MatchUpComponent = () => {
         status: 'warning',
         duration: 3000,
         isClosable: true,
-
       });
       return;
     }
@@ -251,6 +253,7 @@ const MatchUpComponent = () => {
       status: 'info',
       duration: 2000,
       isClosable: true,
+
     });
 
     try {
@@ -287,62 +290,129 @@ const MatchUpComponent = () => {
       navigator.clipboard.writeText(shortUrl).then(() => {
         toast({
           title: 'Short URL Copied!',
-          description: `${shortUrl} copied to clipboard`,
+          description: 'The short URL has been copied to your clipboard',
           status: 'success',
-          duration: 4000,
+          duration: 3000,
           isClosable: true,
         });
       }).catch(() => {
-          toast({
-            title: 'Short URL Generated',
-            description: shortUrl,
-            status: 'info',
-            duration: 6000,
-            isClosable: true,
-          });
-
+        // Fallback: Show the URL in a toast for manual copying
+        toast({
+          title: 'Short URL Generated',
+          description: shortUrl,
+          status: 'success',
+          duration: 10000,
+          isClosable: true,
         });
-
+      });
     } catch (error) {
       console.error('Error generating short URL:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to generate short URL',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
 
-      // Fallback to original long URL
-      const params = new URLSearchParams();
-      params.set('tab', 'matchup');
+  // Component to render player header section with responsive layout
+  const PlayerHeader = ({
+    playerNumber,
+    deck,
+    loading,
+    colorScheme,
+    onSelectDeck,
+    onClearDeck
+  }) => {
+    if (isMobile) {
+      // Mobile layout: Stack elements vertically
+      return (
+        <VStack spacing={2} align="stretch">
+          {/* First row: Player badge */}
+          <HStack spacing={2}>
+            <Badge colorScheme={colorScheme} variant="solid" fontSize="sm">
+              Player {playerNumber}
+            </Badge>
+          </HStack>
 
-      if (deck1Content) {
-        params.append('deck', deck1Content);
-      }
+          {/* Second row: Deck name */}
+          <Box>
 
-      if (deck2Content) {
-        params.append('deck', deck2Content);
-      }
+            <Text fontWeight="semibold" color="gray.700" isTruncated>
+              {deck?.name || 'No Deck Selected'}
+            </Text>
+          </Box>
 
-      const fallbackUrl = `${window.location.origin}/?${params.toString()}`;
+          {/* Third row: Action buttons */}
+          <HStack spacing={2}>
+            {(deck?.cards?.length || 0) > 0 && (
+              <IconButton
+                icon={<RepeatIcon />}
+                size="sm"
+                variant="outline"
+                onClick={() => onClearDeck(playerNumber)}
+                aria-label="Clear deck"
+              />
+            )}
+            <Button
+              leftIcon={<AddIcon />}
+              size="sm"
+              colorScheme={colorScheme}
+              variant="outline"
+              onClick={() => onSelectDeck(playerNumber)}
+              isLoading={loading}
 
-      navigator.clipboard.writeText(fallbackUrl).then(() => {
-        toast({
-          title: 'Fallback URL Copied',
-          description: 'Short URL service unavailable, copied full URL instead',
-          status: 'warning',
-          duration: 4000,
-          isClosable: true,
-        });
-      }).catch(() => {
-          toast({
-            title: 'Error generating URL',
-            description: 'Failed to create shareable URL',
-            status: 'error',
-            duration: 3000,
-            isClosable: true,
-          });
-        });
+              flex="1"
+            >
+              Select Deck
+            </Button>
+          </HStack>
+        </VStack>
+      );
+    } else {
+      // Desktop layout: Keep original horizontal layout
+      return (
+        <HStack justify="space-between" align="center">
+
+          <HStack spacing={2}>
+            <Badge colorScheme={colorScheme} variant="solid" fontSize="sm">
+              Player {playerNumber}
+            </Badge>
+            <Text fontWeight="semibold" color="gray.700" isTruncated>
+              {deck?.name || 'No Deck Selected'}
+            </Text>
+          </HStack>
+          <HStack spacing={2} flexShrink={0}>
+            {(deck?.cards?.length || 0) > 0 && (
+              <IconButton
+                icon={<RepeatIcon />}
+                size="sm"
+                variant="outline"
+                onClick={() => onClearDeck(playerNumber)}
+                aria-label="Clear deck"
+              />
+            )}
+            <Button
+              leftIcon={<AddIcon />}
+              size="sm"
+              colorScheme={colorScheme}
+              variant="outline"
+              onClick={() => onSelectDeck(playerNumber)}
+              isLoading={loading}
+            >
+              Select Deck
+            </Button>
+          </HStack>
+        </HStack>
+      );
     }
   };
 
   return (
     <VStack spacing={6} align="stretch">
-{/* Battle Toolbox - Collapsible */}
+      {/* Battle Toolbox - Collapsible */}
       <Box
         bg={useColorModeValue('white', 'gray.800')}
         border="1px solid"
@@ -409,6 +479,7 @@ const MatchUpComponent = () => {
                       colorScheme={goingFirst ? "blue" : "gray"}
                       onClick={() => setGoingFirst(!goingFirst)}
                       w="100%"
+
                     >
                       {goingFirst ? "First" : "Second"}
                     </Button>
@@ -433,12 +504,15 @@ const MatchUpComponent = () => {
                       onClick={() => setDiceResult(Math.floor(Math.random() * 20) + 1)}
                       w="100%"
                     >
+
                       {diceResult ? `${diceResult}` : "Roll"}
                     </Button>
+
                   </VStack>
                 </Box>
 
                 {/* Leader Ability Toggle */}
+
                 <Box
                   bg={useColorModeValue('gray.50', 'gray.700')}
                   p={2}
@@ -453,7 +527,8 @@ const MatchUpComponent = () => {
                     <Button
                       size="xs"
                       variant={leaderUsed ? "solid" : "outline"}
-                      colorScheme={leaderUsed ? "orange" : "gray"}
+                      colorScheme={leaderUsed ? "red" : "green"}
+
                       onClick={() => setLeaderUsed(!leaderUsed)}
                       w="100%"
                     >
@@ -465,12 +540,11 @@ const MatchUpComponent = () => {
 
               {/* Power Counters */}
               <Box w="100%">
-                <Text fontSize="xs" fontWeight="semibold" color={useColorModeValue('gray.600', 'gray.400')} mb={2}>
-                  Power Counters
+                <Text fontSize="sm" fontWeight="semibold" mb={2} color={useColorModeValue('gray.600', 'gray.400')}>
+                  Power Counters (-10K to +10K)
                 </Text>
-                <Grid templateColumns="repeat(auto-fit, minmax(80px, 1fr))" gap={2}>
+                <Grid templateColumns="repeat(auto-fit, minmax(100px, 1fr))" gap={2}>
                   {powerCounters.map((counter, index) => {
-                    const counterLabels = ["Leader", "Counter 1", "Counter 2", "Counter 3", "Counter 4", "Counter 5"];
                     return (
                       <Box
                         key={index}
@@ -481,14 +555,14 @@ const MatchUpComponent = () => {
                         borderColor={useColorModeValue('gray.200', 'gray.600')}
                       >
                         <VStack spacing={1}>
-                          <Text fontSize="2xs" fontWeight="semibold" color={useColorModeValue('gray.600', 'gray.400')}>
-                            {counterLabels[index]}
+                          <Text fontSize="xs" color={useColorModeValue('gray.600', 'gray.400')}>
+                            Counter {index + 1}
                           </Text>
                           <HStack spacing={1}>
                             <Button
                               size="2xs"
                               onClick={() => updatePowerCounter(index, -1)}
-                              isDisabled={counter === -10}
+                              isDisabled={counter <= -10}
                               colorScheme="red"
                               variant="outline"
                               minW={0}
@@ -496,7 +570,13 @@ const MatchUpComponent = () => {
                             >
                               -
                             </Button>
-                            <Text fontSize="xs" fontWeight="bold" minW="35px" textAlign="center">
+                            <Text
+                              fontSize="xs"
+                              fontWeight="semibold"
+                              minW="35px"
+                              textAlign="center"
+                              color={counter === 0 ? "gray.500" : counter > 0 ? "green.500" : "red.500"}
+                            >
                               {counter === 0 ? "0" : counter > 0 ? `+${counter}K` : `${counter}K`}
                             </Text>
                             <Button
@@ -541,40 +621,81 @@ const MatchUpComponent = () => {
       >
         {/* Player 1 Deck */}
         <GridItem>
-
           <VStack spacing={4} align="stretch" h="100%">
-            <HStack justify="space-between" align="center">
-              <HStack spacing={2}>
-                <Badge colorScheme="blue" variant="solid" fontSize="sm">
-                  Player 1
-                </Badge>
-                <Text fontWeight="semibold" color="gray.700" isTruncated>
-                  {deck1?.name || 'No Deck Selected'}
-                </Text>
-              </HStack>
-              <HStack spacing={2} flexShrink={0}>
-                {(deck1?.cards?.length || 0) > 0 && (
-                  <IconButton
-                    icon={<RepeatIcon />}
-                    size="sm"
-                    variant="outline"
-                    onClick={() => clearDeck(1)}
-                    aria-label="Clear deck"
-                  />
-                )}
-                <Button
-                  leftIcon={<AddIcon />}
-                  size="sm"
-                  colorScheme="blue"
-                  variant="outline"
-                  onClick={() => handleSelectDeck(1)}
-                  isLoading={loadingDeck1}
-                >
-                  Select Deck
-                </Button>
-              </HStack>
+            {isMobile ? (
+              <VStack spacing={2} align="stretch">
+                {/* Mobile: Player badge */}
+                <HStack spacing={2}>
+                  <Badge colorScheme="blue" variant="solid" fontSize="sm">
+                    Player 1
+                  </Badge>
+                </HStack>
 
-            </HStack>
+                {/* Mobile: Deck name */}
+                <Box>
+                  <Text fontWeight="semibold" color="gray.700" isTruncated>
+                    {deck1?.name || 'No Deck Selected'}
+                  </Text>
+                </Box>
+
+                {/* Mobile: Action buttons */}
+                <HStack spacing={2}>
+                  {(deck1?.cards?.length || 0) > 0 && (
+                    <IconButton
+                      icon={<RepeatIcon />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => clearDeck(1)}
+                      aria-label="Clear deck"
+                    />
+                  )}
+                  <Button
+                    leftIcon={<AddIcon />}
+                    size="sm"
+                    colorScheme="blue"
+                    variant="outline"
+                    onClick={() => handleSelectDeck(1)}
+                    isLoading={loadingDeck1}
+                    flex="1"
+                  >
+                    Select Deck
+                  </Button>
+                </HStack>
+              </VStack>
+            ) : (
+              <HStack justify="space-between" align="center">
+                <HStack spacing={2}>
+                  <Badge colorScheme="blue" variant="solid" fontSize="sm">
+                    Player 1
+                  </Badge>
+                  <Text fontWeight="semibold" color="gray.700" isTruncated>
+                    {deck1?.name || 'No Deck Selected'}
+                  </Text>
+                </HStack>
+                <HStack spacing={2} flexShrink={0}>
+                  {(deck1?.cards?.length || 0) > 0 && (
+                    <IconButton
+                      icon={<RepeatIcon />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => clearDeck(1)}
+                      aria-label="Clear deck"
+                    />
+                  )}
+                  <Button
+                    leftIcon={<AddIcon />}
+                    size="sm"
+
+                    colorScheme="blue"
+                    variant="outline"
+                    onClick={() => handleSelectDeck(1)}
+                    isLoading={loadingDeck1}
+                  >
+                    Select Deck
+                  </Button>
+                </HStack>
+              </HStack>
+            )}
 
             {loadingDeck1 ? (
               <Box textAlign="center" py={8}>
@@ -592,39 +713,85 @@ const MatchUpComponent = () => {
         </GridItem>
 
         {/* Player 2 Deck */}
+
         <GridItem>
           <VStack spacing={4} align="stretch" h="100%">
-            <HStack justify="space-between" align="center">
-              <HStack spacing={2}>
-                <Badge colorScheme="red" variant="solid" fontSize="sm">
-                  Player 2
-                </Badge>
-                <Text fontWeight="semibold" color="gray.700" isTruncated>
-                  {deck2?.name || 'No Deck Selected'}
-                </Text>
-              </HStack>
-              <HStack spacing={2} flexShrink={0}>
-                {(deck2?.cards?.length || 0) > 0 && (
-                  <IconButton
-                    icon={<RepeatIcon />}
+            {isMobile ? (
+              <VStack spacing={2} align="stretch">
+                {/* Mobile: Player badge */}
+                <HStack spacing={2}>
+                  <Badge colorScheme="red" variant="solid" fontSize="sm">
+                    Player 2
+                  </Badge>
+                </HStack>
+
+                {/* Mobile: Deck name */}
+                <Box>
+                  <Text fontWeight="semibold" color="gray.700" isTruncated>
+                    {deck2?.name || 'No Deck Selected'}
+                  </Text>
+                </Box>
+
+
+                {/* Mobile: Action buttons */}
+                <HStack spacing={2}>
+                  {(deck2?.cards?.length || 0) > 0 && (
+                    <IconButton
+                      icon={<RepeatIcon />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => clearDeck(2)}
+                      aria-label="Clear deck"
+                    />
+                  )}
+                  <Button
+                    leftIcon={<AddIcon />}
+
                     size="sm"
+                    colorScheme="red"
                     variant="outline"
-                    onClick={() => clearDeck(2)}
-                    aria-label="Clear deck"
-                  />
-                )}
-                <Button
-                  leftIcon={<AddIcon />}
-                  size="sm"
-                  colorScheme="red"
-                  variant="outline"
-                  onClick={() => handleSelectDeck(2)}
-                  isLoading={loadingDeck2}
-                >
-                  Select Deck
-                </Button>
+                    onClick={() => handleSelectDeck(2)}
+                    isLoading={loadingDeck2}
+                    flex="1"
+                  >
+                    Select Deck
+                  </Button>
+                </HStack>
+              </VStack>
+            ) : (
+              <HStack justify="space-between" align="center">
+                <HStack spacing={2}>
+                  <Badge colorScheme="red" variant="solid" fontSize="sm">
+                    Player 2
+                  </Badge>
+                  <Text fontWeight="semibold" color="gray.700" isTruncated>
+                    {deck2?.name || 'No Deck Selected'}
+                  </Text>
+                </HStack>
+                <HStack spacing={2} flexShrink={0}>
+                  {(deck2?.cards?.length || 0) > 0 && (
+                    <IconButton
+                      icon={<RepeatIcon />}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => clearDeck(2)}
+                      aria-label="Clear deck"
+                    />
+                  )}
+                  <Button
+                    leftIcon={<AddIcon />}
+                    size="sm"
+                    colorScheme="red"
+                    variant="outline"
+                    onClick={() => handleSelectDeck(2)}
+
+                    isLoading={loadingDeck2}
+                  >
+                    Select Deck
+                  </Button>
+                </HStack>
               </HStack>
-            </HStack>
+            )}
 
             {loadingDeck2 ? (
               <Box textAlign="center" py={8}>


### PR DESCRIPTION
- Add useBreakpointValue to detect mobile layout
- Adjust controls (slider, sort) to stack vertically on mobile
- Update cards grid and stats to be mobile-friendly
- Improve keyword and color distribution display for small screens
- Refactor layout logic for better responsiveness

Changelog: feature,other