### PR TITLE
Adjust CardTags icon and button sizes for consistency

### DIFF
--- a/frontend/src/components/CardTags.js
+++ b/frontend/src/components/CardTags.js
@@ -247,8 +247,8 @@ const CardTags = ({
   }
 
   // Icon size mapping
-  const iconSize = size === "sm" ? 3 : 4;
-  const buttonSize = size === "sm" ? "xs" : "sm";
+  const iconSize = size === "sm" ? 4 : 6;
+  const buttonSize = size === "sm" ? "sm" : "md";
 
   // TagIcon with portal tooltip that bypasses overflow:hidden
   const TagIcon = ({

--- a/frontend/src/components/ListViewCollect.js
+++ b/frontend/src/components/ListViewCollect.js
@@ -102,13 +102,6 @@ const ListViewCollect = ({ cards, onCardClick, showProxies, onCountUpdate }) => 
           suppressHydrationWarning={true}
           position="relative"
         >
-          {/* Top right - CardTags and LocationDisplay for desktop only */}
-          {!isMobile && hasTags && (
-            <HStack position="absolute" top={2} right={2} zIndex={2} spacing={2}>
-              <CardTags card={card} interactive={false} size="xl" showTooltips={true} />
-            </HStack>
-          )}
-
           <VStack spacing={3} align="stretch">
             {/* First Row: Card Image and Basic Info */}
             <Flex>
@@ -141,7 +134,7 @@ const ListViewCollect = ({ cards, onCardClick, showProxies, onCountUpdate }) => 
                     </Text>
                   </HStack>
                   {hasTags && (
-                    <CardTags card={card} interactive={false} size="xl" showTooltips={true} />
+                    <CardTags card={card} interactive={false} size="sm" showTooltips={true} />
                   )}
                 </HStack>
 
@@ -231,7 +224,7 @@ const ListViewCollect = ({ cards, onCardClick, showProxies, onCountUpdate }) => 
                 <LocationDisplay card={card} />
               )}
               {hasTags && (
-                <CardTags card={card} interactive={false} size="sm" showTooltips={true} />
+                <CardTags card={card} interactive={false} size="md" showTooltips={true} />
               )}
             </HStack>
           )}


### PR DESCRIPTION
- increased icon size for "sm" and default CardTags
- increased button size for "sm" and default CardTags
- updated ListViewCollect to use smaller CardTags in main row
- updated ListViewCollect to use medium CardTags in location row
- removed redundant CardTags display from top right on desktop

Changelog: feature, removed, other