### PR TITLE
Add server-side sorting to card search API

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1193,12 +1193,27 @@ app.get('/api/public/cards/search', validateSearchKeyword, async (req, res) => {
 
 // Enhanced search
 app.get('/api/cards/search', isAuthenticated, validateSearchKeyword, async (req, res) => {
-  const { keyword, ownedOnly, showProxies, limit = 50, offset = 0 } = req.query;
+  const {
+    keyword,
+    ownedOnly,
+    showProxies,
+    limit = 50,
+    offset = 0,
+    sortBy = 'name',
+    sortOrder = 'asc'
+  } = req.query;
   const userId = req.user.id;
 
   // Convert limit and offset to integers
   const limitInt = Math.min(parseInt(limit) || 50, 100); // Cap at 100 per page
   const offsetInt = parseInt(offset) || 0;
+
+  // Validate sort parameters
+  const validSortFields = ['name', 'rarity', 'card_code', 'tags', 'cost', 'power'];
+  const validSortOrders = ['asc', 'desc'];
+
+  const sortByField = validSortFields.includes(sortBy) ? sortBy : 'name';
+  const sortOrderDir = validSortOrders.includes(sortOrder.toLowerCase()) ? sortOrder.toLowerCase() : 'asc';
 
   // Allow empty keyword ONLY if ownedOnly or showProxies is true
   const allowEmptyKeyword = ownedOnly === 'true' || showProxies === 'true';
@@ -1423,7 +1438,55 @@ app.get('/api/cards/search', isAuthenticated, validateSearchKeyword, async (req,
       }
     }
 
-    orderClauses.push('c.name ASC');
+    // Add user-selected sorting
+    switch (sortByField) {
+      case 'rarity':
+        // Define rarity order in SQL
+        orderClauses.push(`
+          CASE c.rarity
+          WHEN 'C' THEN 1
+          WHEN 'UC' THEN 2
+          WHEN 'R' THEN 3
+          WHEN 'SR' THEN 4
+          WHEN 'SEC' THEN 5
+          WHEN 'L' THEN 6
+          WHEN 'SP' THEN 7
+          ELSE 0
+          END ${sortOrderDir.toUpperCase()}
+        `);
+        orderClauses.push('c.name ASC'); // Secondary sort by name
+        break;
+
+      case 'card_code':
+        orderClauses.push(`c.card_code ${sortOrderDir.toUpperCase()}`);
+        orderClauses.push('c.name ASC'); // Secondary sort by name
+        break;
+
+      case 'tags':
+        // Count total tags (user_tags + global_tags)
+        orderClauses.push(`
+          (COALESCE(array_length(ARRAY_AGG(DISTINCT ut.tag_type) FILTER (WHERE ut.tag_type IS NOT NULL), 1), 0) +
+          COALESCE(array_length(ARRAY_AGG(DISTINCT gt.tag_type) FILTER (WHERE gt.tag_type IS NOT NULL), 1), 0))
+${sortOrderDir.toUpperCase()}
+`);
+        orderClauses.push('c.name ASC'); // Secondary sort by name
+        break;
+
+      case 'cost':
+        orderClauses.push(`c.cost ${sortOrderDir.toUpperCase()} NULLS LAST`);
+        orderClauses.push('c.name ASC'); // Secondary sort by name
+        break;
+
+      case 'power':
+        orderClauses.push(`c.power ${sortOrderDir.toUpperCase()} NULLS LAST`);
+        orderClauses.push('c.name ASC'); // Secondary sort by name
+        break;
+
+      case 'name':
+      default:
+        orderClauses.push(`c.name ${sortOrderDir.toUpperCase()}`);
+        break;
+    }
 
     if (orderClauses.length > 0) {
       baseQuery += ' ORDER BY ' + orderClauses.join(', ');

--- a/frontend/src/components/CardSearch.js
+++ b/frontend/src/components/CardSearch.js
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
-  Box, Text, VStack, HStack, Spinner, Button,
+  Box, Text, VStack, HStack, Spinner, Button, Icon,
   useDisclosure, IconButton, FormControl, FormLabel, Switch,
   Tooltip, Slider, SliderTrack, SliderFilledTrack, SliderThumb,
   Menu, MenuButton, MenuList, MenuItem, useBreakpointValue
@@ -167,60 +167,16 @@ const IsolatedResultsComponent = React.memo(({
   results,
   viewMode,
   mode,
-  sortMode,
-  sortReverse,
+  sortMode,      // Keep these props for potential future use
+  sortReverse,   // Keep these props for potential future use
   onCardClick,
   onCountUpdate,
   showProxies,
   thumbnailSize,
   loading
 }) => {
-  // Sort results within this isolated component (server already limits results)
-  const sortedResults = useMemo(() => {
-    if (!Array.isArray(results) || results.length === 0) {
-      return [];
-    }
 
-    const sorted = [...results].sort((a, b) => {
-      let comparison = 0;
-
-      switch (sortMode) {
-        case 'rarity':
-          const rarityOrder = { 'C': 1, 'UC': 2, 'R': 3, 'SR': 4, 'SEC': 5, 'L': 6, 'SP': 7 };
-          const aRarity = rarityOrder[a.rarity] || 0;
-          const bRarity = rarityOrder[b.rarity] || 0;
-          comparison = aRarity - bRarity;
-          if (comparison === 0) comparison = a.name.localeCompare(b.name);
-          break;
-
-        case 'card_code':
-          comparison = (a.card_code || '').localeCompare(b.card_code || '');
-          if (comparison === 0) comparison = a.name.localeCompare(b.name);
-          break;
-
-        case 'tags':
-          const getTagCount = (card) => {
-            const userTags = Array.isArray(card.user_tags) ? card.user_tags.length : 0;
-            const globalTags = Array.isArray(card.global_tags) ? card.global_tags.length : 0;
-            return userTags + globalTags;
-          };
-          const aTagCount = getTagCount(a);
-          const bTagCount = getTagCount(b);
-          comparison = aTagCount - bTagCount;
-          if (comparison === 0) comparison = a.name.localeCompare(b.name);
-          break;
-
-        default:
-          comparison = a.name.localeCompare(b.name);
-      }
-
-      return sortReverse ? -comparison : comparison;
-    });
-
-    return sorted;
-  }, [results, sortMode, sortReverse]);
-
-  if (loading || !sortedResults.length) {
+  if (loading || !results || results.length === 0) {
     return null;
   }
 
@@ -228,21 +184,21 @@ const IsolatedResultsComponent = React.memo(({
   if (viewMode === 'list') {
     return mode === 'collection' ? (
       <ListViewCollect
-        cards={sortedResults}
+        cards={results}
         onCardClick={onCardClick}
         onCountUpdate={onCountUpdate}
         showProxies={showProxies}
       />
     ) : (
       <ListViewBuilder
-        cards={sortedResults}
+        cards={results}
         onCardClick={onCardClick}
       />
     );
   } else {
     return mode === 'collection' ? (
       <ThumbViewCollect
-        cards={sortedResults}
+        cards={results}
         onCardClick={onCardClick}
         onCountUpdate={onCountUpdate}
         showProxies={showProxies}
@@ -250,7 +206,7 @@ const IsolatedResultsComponent = React.memo(({
       />
     ) : (
       <ThumbViewBuilder
-        cards={sortedResults}
+        cards={results}
         onCardClick={onCardClick}
         thumbnailSize={thumbnailSize}
       />
@@ -377,7 +333,7 @@ function CardSearch({
   }, []);
 
   // Search function with proper error handling
-  const performSearch = useCallback(async (keyword, ownedOnly = false, page = 1, limitPerPage = 25) => {
+  const performSearch = useCallback(async (keyword, ownedOnly = false, page = 1, limitPerPage = 25, sortBy = sortMode, sortOrder = sortReverse) => {
     const validation = validateSearchInput(keyword, ownedOnly);
     if (!validation.isValid && keyword.trim() && !ownedOnly) {
       setResults([]);
@@ -401,7 +357,9 @@ function CardSearch({
       ownedOnly: ownedOnly.toString(),
       showProxies: 'true',
       limit: limitPerPage.toString(),
-      offset: ((page - 1) * limitPerPage).toString()
+      offset: ((page - 1) * limitPerPage).toString(),
+      sortBy: sortBy,
+      sortOrder: sortOrder ? 'desc' : 'asc'
     };
 
     const paramsString = JSON.stringify(searchParams);
@@ -463,20 +421,33 @@ function CardSearch({
     } finally {
       setLoading(false);
     }
-  }, [apiUrl]);
+  }, [apiUrl, sortMode, sortReverse, ensureTagsAreArrays]);
 
   const handlePageChange = useCallback((newPage) => {
     if (newPage < 1) return;
     setCurrentPage(newPage);
-    performSearch(searchTerm.trim(), inCollection, newPage, itemsPerPage);
-  }, [searchTerm, inCollection, itemsPerPage, performSearch]);
+    performSearch(searchTerm.trim(), inCollection, newPage, itemsPerPage, sortMode, sortReverse); // ADD sortMode and sortReverse
+  }, [searchTerm, inCollection, itemsPerPage, sortMode, sortReverse, performSearch]);
 
   const handleItemsPerPageChange = useCallback((newItemsPerPage) => {
     if (newItemsPerPage <= 0) return;
     setItemsPerPage(newItemsPerPage);
     setCurrentPage(1);
-    performSearch(searchTerm.trim(), inCollection, 1, newItemsPerPage);
-  }, [searchTerm, inCollection, performSearch]);
+    performSearch(searchTerm.trim(), inCollection, 1, newItemsPerPage, sortMode, sortReverse);
+  }, [searchTerm, inCollection, sortMode, sortReverse, performSearch]);
+
+  const handleSortModeChange = useCallback((newSortMode) => {
+    setSortMode(newSortMode);
+    setCurrentPage(1); // Reset to first page
+    performSearch(searchTerm.trim(), inCollection, 1, itemsPerPage, newSortMode, sortReverse);
+  }, [searchTerm, inCollection, itemsPerPage, sortReverse, performSearch]);
+
+  const handleSortReverseChange = useCallback(() => {
+    const newReverse = !sortReverse;
+    setSortReverse(newReverse);
+    setCurrentPage(1); // Reset to first page
+    performSearch(searchTerm.trim(), inCollection, 1, itemsPerPage, sortMode, newReverse);
+  }, [searchTerm, inCollection, itemsPerPage, sortMode, sortReverse, performSearch]);
 
   // Manual search trigger
   const handleManualSearch = useCallback(() => {
@@ -620,7 +591,7 @@ function CardSearch({
         });
       }
     }
-  }, [inCollection, isClient]);
+  }, [inCollection, isClient, sortMode, sortReverse]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -772,32 +743,38 @@ function CardSearch({
                   </Tooltip>
 
                   <Menu>
-                    <MenuButton as={IconButton} icon={<SortIcon />} size="sm" variant="outline" />
+                    <MenuButton
+                      as={Button}
+                      rightIcon={<ChevronDownIcon />}
+                      leftIcon={<Icon as={getSortIcon(sortMode)} />}
+                      variant="outline"
+                      size="sm"
+                    >
+                    Sort
+                    </MenuButton>
                     <MenuList>
-                      <MenuItem onClick={() => setSortMode('name')}>
-                        <HStack><FiSearch /><Text>Name</Text></HStack>
+                      <MenuItem icon={<FiSearch />} onClick={() => handleSortModeChange('name')}>
+                      Name
                       </MenuItem>
-                      <MenuItem onClick={() => setSortMode('rarity')}>
-                        <HStack><FiHash /><Text>Rarity</Text></HStack>
+                      <MenuItem icon={<FiHash />} onClick={() => handleSortModeChange('rarity')}>
+                      Rarity
                       </MenuItem>
-                      <MenuItem onClick={() => setSortMode('card_code')}>
-                        <HStack><FiType /><Text>Card Code</Text></HStack>
+                      <MenuItem icon={<FiType />} onClick={() => handleSortModeChange('card_code')}>
+                      Card Code
                       </MenuItem>
-                      <MenuItem onClick={() => setSortMode('tags')}>
-                        <HStack><FiTag /><Text>Tags</Text></HStack>
+                      <MenuItem icon={<FiTag />} onClick={() => handleSortModeChange('tags')}>
+                      Tags
                       </MenuItem>
                     </MenuList>
                   </Menu>
 
-                  <Tooltip label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}>
-                    <IconButton
-                      icon={sortReverse ? <BsSortUp /> : <BsSortDown />}
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setSortReverse(!sortReverse)}
-                      aria-label={`Sort ${sortReverse ? 'ascending' : 'descending'}`}
-                    />
-                  </Tooltip>
+                  <IconButton
+                    icon={sortReverse ? <BsSortDown /> : <BsSortUp />}
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSortReverseChange}  // CHANGED: use new handler
+                    aria-label="Toggle sort direction"
+                  />
                 </HStack>
 
                 {/* Second row: Collection switches */}


### PR DESCRIPTION
- added support for sortBy and sortOrder query parameters to /api/cards/search
- validated sort fields and order to prevent invalid input
- implemented SQL ordering for name, rarity, card_code, tags, cost, and power
- removed client-side sorting from CardSearch.js in favor of server-side sorting
- updated frontend to send sortBy and sortOrder to backend and handle sort changes

Changelog: feature