### PR TITLE
Improve deck sorting by category for cost and name modes

### DIFF
--- a/frontend/src/hooks/useDeckBuilder.js
+++ b/frontend/src/hooks/useDeckBuilder.js
@@ -232,22 +232,52 @@ export const useDeckBuilder = () => {
         sortedNonLeaderCards = nonLeaderCards.sort((a, b) => {
           const aData = getCardData(a);
           const bData = getCardData(b);
+
+          // Define category order: CHARACTER, STAGE, EVENT
+          const categoryOrder = { 'CHARACTER': 1, 'STAGE': 2, 'EVENT': 3 };
+          const aCategory = categoryOrder[aData?.category] || 999;
+          const bCategory = categoryOrder[bData?.category] || 999;
+
+          // First, sort by category
+          const categoryCompare = aCategory - bCategory;
+          if (categoryCompare !== 0) {
+            return sortReverse ? -categoryCompare : categoryCompare;
+          }
+
+          // Then, sort by cost within the same category
           const costCompare = (aData?.cost || 0) - (bData?.cost || 0);
           if (costCompare !== 0) {
             return sortReverse ? -costCompare : costCompare;
           }
+
+          // Finally, sort by name if cost is the same
           const nameCompare = (aData?.name || '').localeCompare(bData?.name || '');
           return sortReverse ? -nameCompare : nameCompare;
         });
         break;
+
       case 'name':
         sortedNonLeaderCards = nonLeaderCards.sort((a, b) => {
           const aData = getCardData(a);
           const bData = getCardData(b);
+
+          // Define category order: CHARACTER, STAGE, EVENT
+          const categoryOrder = { 'CHARACTER': 1, 'STAGE': 2, 'EVENT': 3 };
+          const aCategory = categoryOrder[aData?.category] || 999;
+          const bCategory = categoryOrder[bData?.category] || 999;
+
+          // First, sort by category
+          const categoryCompare = aCategory - bCategory;
+          if (categoryCompare !== 0) {
+            return sortReverse ? -categoryCompare : categoryCompare;
+          }
+
+          // Then, sort by name within the same category
           const nameCompare = (aData?.name || '').localeCompare(bData?.name || '');
           return sortReverse ? -nameCompare : nameCompare;
         });
         break;
+
       case 'type':
         sortedNonLeaderCards = nonLeaderCards.sort((a, b) => {
           const aData = getCardData(a);
@@ -260,6 +290,7 @@ export const useDeckBuilder = () => {
           return sortReverse ? -nameCompare : nameCompare;
         });
         break;
+
       default:
         sortedNonLeaderCards = nonLeaderCards;
     }


### PR DESCRIPTION
- add category-based sorting for 'cost' and 'name' sort modes
- ensure CHARACTER, STAGE, EVENT order is respected in sorting
- keep sorting stable for cost and name within the same category

Changelog: feature